### PR TITLE
Implement shareReplay, switch form to async pipe

### DIFF
--- a/src/app/edit-pet/edit-pet.component.html
+++ b/src/app/edit-pet/edit-pet.component.html
@@ -1,9 +1,7 @@
 <div>
   <h1>Edit Pet</h1>
   <hr>
-  <div *ngIf="this.pet$">
-    <app-pet-form [pet]="this.pet$ | async"></app-pet-form>
-  </div>
+  <app-pet-form [pet]="this.pet$ | async"></app-pet-form>
   <button mat-raised-button color="primary" id="save_button" type="button" (click)="submit()">Save Edits</button>
   <button mat-raised-button color="warn" type="button" (click)="cancel()">Cancel</button>
 </div>

--- a/src/app/edit-pet/edit-pet.component.html
+++ b/src/app/edit-pet/edit-pet.component.html
@@ -1,10 +1,9 @@
 <div>
   <h1>Edit Pet</h1>
   <hr>
-  <div class="spinner" *ngIf="!this.loaded">
-    <mat-spinner></mat-spinner>
+  <div *ngIf="this.pet$">
+    <app-pet-form [pet]="this.pet$ | async"></app-pet-form>
   </div>
-  <app-pet-form></app-pet-form>
   <button mat-raised-button color="primary" id="save_button" type="button" (click)="submit()">Save Edits</button>
   <button mat-raised-button color="warn" type="button" (click)="cancel()">Cancel</button>
 </div>

--- a/src/app/edit-pet/edit-pet.component.ts
+++ b/src/app/edit-pet/edit-pet.component.ts
@@ -21,17 +21,6 @@ export class EditPetComponent implements OnInit {
 
   ngOnInit(): void {
     this.petService.selectedPetChanged(Number(this.route.snapshot.paramMap.get('id')));
-    let data: Pet | undefined;
-    this.pet$
-      .pipe(
-        take(1)
-      )
-      .subscribe(pet => {
-        if (pet) {
-          this.form.setFormValues(pet);
-        }
-        this.loaded = true;
-      });
   }
 
   submit(): void {
@@ -42,7 +31,10 @@ export class EditPetComponent implements OnInit {
         .pipe(
           take(1)
         )
-        .subscribe(_ => this.router.navigate(['view-pet', pet.id]));
+        .subscribe(_ => {
+          this.petService.refreshPets();
+          this.router.navigate(['view-pet', pet.id])
+        });
     }
   }
 

--- a/src/app/new-pet/new-pet.component.ts
+++ b/src/app/new-pet/new-pet.component.ts
@@ -20,13 +20,16 @@ export class NewPetComponent implements OnInit {
 
   submit() {
     const pet = this.form.onSubmit();
-    if (pet){
+    if (pet) {
       pet.id = 5;
       this.petService.addPet(pet)
-            .pipe(
-              take(1)
-            )
-            .subscribe(_ => this.router.navigate(['view-pet', pet.id]));
+        .pipe(
+          take(1)
+        )
+        .subscribe(_ => {
+          this.petService.refreshPets();
+          this.router.navigate(['view-pet', pet.id]);
+        });
     }
     return false;
   }

--- a/src/app/pet-form/pet-form.component.ts
+++ b/src/app/pet-form/pet-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, FormArray, Validators } from '@angular/forms';
 import { Location, formatDate } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
@@ -14,6 +14,7 @@ import { FileUploadService } from '../file-upload.service';
   styleUrls: ['./pet-form.component.css']
 })
 export class PetFormComponent implements OnInit {
+  @Input() pet: Pet | null | undefined;
 
   newPetForm!: FormGroup;
   submitted: boolean;
@@ -44,7 +45,11 @@ export class PetFormComponent implements OnInit {
     });
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {
+    if(this.pet){
+      this.setFormValues(this.pet);
+    }
+  }
 
   setFormValues(pet: Pet): void {
     this.newPetForm.controls['name'].setValue(pet.name);

--- a/src/app/pet.service.ts
+++ b/src/app/pet.service.ts
@@ -20,9 +20,8 @@ export class PetService {
   private _petsData$ = new BehaviorSubject<void>(undefined);
   apiRequest$ = this.http.get<Pet[]>(this.petsUrl)
     .pipe(
-      tap(pet => {
-        console.log('fetch pets');
-        return pet;
+      tap(pets => {
+        console.log('fetched ' + pets.length + ' pets');
       })
     );
 

--- a/src/app/pet.service.ts
+++ b/src/app/pet.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { BehaviorSubject, combineLatest, Observable, of } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { catchError, map, tap } from 'rxjs/operators';
+import { catchError, map, mergeMap, shareReplay, tap } from 'rxjs/operators';
 
 import { Pet } from './pet';
 import { PETS } from './mock-pets';
@@ -17,11 +17,19 @@ export class PetService {
     headers: new HttpHeaders({ 'Content-Type': 'application/json' })
   };
 
-  pets$ = this.http.get<Pet[]>(this.petsUrl)
+  private _petsData$ = new BehaviorSubject<void>(undefined);
+  apiRequest$ = this.http.get<Pet[]>(this.petsUrl)
     .pipe(
-      tap(_ => console.log('fetched pets')),
-      catchError(this.handleError<Pet[]>('fetch pets', []))
+      tap(pet => {
+        console.log('fetch pets');
+        return pet;
+      })
     );
+
+  pets$ = this._petsData$.pipe(
+    mergeMap(() => this.apiRequest$),
+    shareReplay(1)
+  );
 
   private selectedPetSubject = new BehaviorSubject<number>(0);
   selectedPet$ = this.selectedPetSubject.asObservable();
@@ -41,6 +49,10 @@ export class PetService {
 
   selectedPetChanged(id: number): void {
     this.selectedPetSubject.next(id);
+  }
+
+  refreshPets(){
+    this._petsData$.next();
   }
 
   /** PUT */

--- a/src/app/view-pet/view-pet.component.ts
+++ b/src/app/view-pet/view-pet.component.ts
@@ -25,7 +25,10 @@ export class ViewPetComponent implements OnInit {
       .pipe(
         take(1)
       )
-      .subscribe(_ => this.router.navigate(['pets']));
+      .subscribe(_ => {
+        this.petService.refreshPets();
+        this.router.navigate(['pets'])
+      });
   }
 
   toggle() {


### PR DESCRIPTION
I've set up shareReplay so that Pets is cached rather than making a get request on every page load. This is only refreshed on actions that would update the data. It is called in the subscription and not the service. I also changed the form to accept a Pet so that the pet form could use the async pipe.
I'm putting in a PR now without many changes because I'm going to switch to working with some more Material and CSS for a bit. Please do let me know if I am not using best practices or if you'd suggest any other changes. Thanks!