### PR TITLE
Add calendar view, add/edit/delete events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/platform-browser-dynamic": "^14.0.0",
         "@angular/router": "^14.0.0",
         "angular-in-memory-web-api": "^0.14.0",
+        "moment": "^2.29.4",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.4"
@@ -8056,6 +8057,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -17975,6 +17984,11 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser-dynamic": "^14.0.0",
     "@angular/router": "^14.0.0",
     "angular-in-memory-web-api": "^0.14.0",
+    "moment": "^2.29.4",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,13 +6,14 @@ import { PageNotFoundComponent } from './page-not-found/page-not-found.component
 import { NewPetComponent } from './new-pet/new-pet.component';
 import { AccountPetsComponent } from './account-pets/account-pets.component';
 import { ViewPetComponent } from './view-pet/view-pet.component';
-
+import { CalendarContainerComponent } from './calendar/components/calendar-container/calendar-container.component';
 
 const routes: Routes = [
   { path: '', redirectTo: '/', pathMatch: 'full' },
   { path: 'profile', component: AccountProfileComponent },
   { path: 'new-pet', component: NewPetComponent },
   { path: 'pets', component: AccountPetsComponent },
+  { path: 'calendar', component: CalendarContainerComponent },
   { path: 'edit-pet/:id', component: EditPetComponent },
   { path: 'view-pet/:id', component: ViewPetComponent },
   { path: '404', component: PageNotFoundComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,11 @@ import { AccountPetsComponent } from './account-pets/account-pets.component';
 import { ViewPetComponent } from './view-pet/view-pet.component';
 import { ConfirmDialogComponent } from './confirm-dialog/confirm-dialog.component';
 
+import { CalendarComponent } from './calendar/components/calendar/calendar.component';
+import { CalendarContainerComponent } from './calendar/components/calendar-container/calendar-container.component';
+import { EventFormComponent } from './calendar/components/event-form/event-form.component';
+import { ViewEventComponent } from './calendar/components/view-event/view-event.component';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -30,7 +35,11 @@ import { ConfirmDialogComponent } from './confirm-dialog/confirm-dialog.componen
     MainNavComponent,
     AccountPetsComponent,
     ViewPetComponent,
-    ConfirmDialogComponent
+    ConfirmDialogComponent,
+    CalendarComponent,
+    CalendarContainerComponent,
+    EventFormComponent,
+    ViewEventComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/calendar/calendar-event.ts
+++ b/src/app/calendar/calendar-event.ts
@@ -1,0 +1,11 @@
+import { Moment } from "moment";
+
+export interface CalendarEvent {
+  id: number,
+  date: Moment,
+  allDay: boolean,
+  startTime?: string,
+  endTime?: string,
+  name: string,
+  details: string
+}

--- a/src/app/calendar/calendar.service.spec.ts
+++ b/src/app/calendar/calendar.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CalendarService } from './calendar.service';
+
+describe('CalendarService', () => {
+  let service: CalendarService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CalendarService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/calendar/calendar.service.ts
+++ b/src/app/calendar/calendar.service.ts
@@ -1,0 +1,150 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import * as moment from 'moment';
+import { take, BehaviorSubject, tap, mergeMap, shareReplay, combineLatest, map, catchError, Observable, of } from 'rxjs';
+import { CalendarEvent } from './calendar-event';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CalendarService {
+
+  private eventsUrl = 'api/events';
+  httpOptions = {
+    headers: new HttpHeaders({ 'Content-Type': 'application/json' })
+  };
+
+  //fetch all user events
+  private eventsData$ = new BehaviorSubject<void>(undefined);
+  private apiRequest$ = this.http.get<CalendarEvent[]>(this.eventsUrl)
+    .pipe(
+      tap(_ => {
+        console.log('fetch events');
+      })
+    );
+  //cache events
+  private events$ = this.eventsData$.pipe(
+    mergeMap(() => this.apiRequest$),
+    shareReplay(1)
+  );
+
+  //get events in month
+  private MonthYearSubject = new BehaviorSubject<[number, number]>([parseInt(moment().format('M')), parseInt(moment().format('YYYY'))]);
+  private MonthYear$ = this.MonthYearSubject.asObservable();
+  monthEvents$ = combineLatest([
+    this.events$,
+    this.MonthYear$
+  ]).pipe(
+    tap(res => console.log(`month: ${res[1][0]}, year: ${res[1][1]}`)),
+    map(([events, date]) => {
+      let match: CalendarEvent[] = [];
+      for (let x of events) {
+        if (parseInt(moment(x.date).format('M')) === date[0] && parseInt(moment(x.date).format('YYYY')) === date[1]) {
+          match.push(x);
+        }
+      }
+      return match;
+    }),
+    tap(res => console.log(`events: ${res.length}`)),
+    catchError(this.handleError<CalendarEvent>('selectMonth')),
+    shareReplay(1)
+  );
+
+  //get selected event by id
+  private selectedEventSubject = new BehaviorSubject<number>(0);
+  private selectedEvent$ = this.selectedEventSubject.asObservable();
+  event$ = combineLatest([
+    this.events$,
+    this.selectedEvent$
+  ]).pipe(
+    map(([events, id]) =>
+      events.find(event => event.id === id)
+    ),
+    tap(event => console.log('selected event', event?.id)),
+    catchError(this.handleError<CalendarEvent>('getEvent'))
+  );
+
+  constructor(private http: HttpClient) { }
+
+  refreshEvents() {
+    this.eventsData$.next();
+  }
+
+  selectMonth(month: number, year: number) {
+    this.MonthYearSubject.next([month, year]);
+  }
+
+  selectEvent(id: number) {
+    this.selectedEventSubject.next(id);
+  }
+
+  getDayEvents(day: moment.Moment): Observable<CalendarEvent[]> {
+    return this.monthEvents$.pipe(
+      map(res => {
+        let events: CalendarEvent[] = [];
+        for (let event of (res as CalendarEvent[])) {
+          if (moment(event.date).format('M D, YYYY') === moment(day).format('M D, YYYY')) {
+            events.push(event);
+          }
+        }
+        return events;
+      })
+    );
+  }
+
+  getStringEvents(): Observable<string[]> {
+    return this.monthEvents$.pipe(
+      map(res => {
+        let stringified: string[] = [];
+        for (let event of (res as CalendarEvent[])) {
+          stringified.push(moment(event.date).format('MMMM D, YYYY'));
+        }
+        return stringified;
+      })
+    );
+  }
+
+  addCalendarEvent(event: CalendarEvent): Observable<CalendarEvent> {
+    return this.http.post<CalendarEvent>(this.eventsUrl, event, this.httpOptions).pipe(
+      tap((newEvent: CalendarEvent) => console.log('added event', newEvent.id)),
+      catchError(this.handleError<CalendarEvent>('addCalendarEvent'))
+    );
+  }
+
+  editCalendarEvent(event: CalendarEvent): Observable<any> {
+    return this.http.put(this.eventsUrl, event, this.httpOptions).pipe(
+      tap(_ => console.log(`updated event id=${event.id}`)),
+      catchError(this.handleError<any>('updateCalendarEvent'))
+    );
+  }
+
+  deleteCalendarEvent(id: number): Observable<CalendarEvent> {
+    const url = `${this.eventsUrl}/${id}`;
+
+    return this.http.delete<CalendarEvent>(url, this.httpOptions).pipe(
+      tap(_ => console.log(`deleted event id=${id}`)),
+      catchError(this.handleError<CalendarEvent>('deleteCalendarEvent'))
+    );
+  }
+
+  /**
+* Handle Http operation that failed.
+* Let the app continue.
+*
+* @param operation - name of the operation that failed
+* @param result - optional value to return as the observable result
+*/
+  private handleError<T>(operation = 'operation', result?: T) {
+    return (error: any): Observable<T> => {
+
+      // TODO: send the error to remote logging infrastructure
+      console.error(error); // log to console instead
+
+      // TODO: better job of transforming error for user consumption
+      console.log(`${operation} failed: ${error.message}`);
+
+      // Let the app keep running by returning an empty result.
+      return of(result as T);
+    };
+  }
+}

--- a/src/app/calendar/components/calendar-container/calendar-container.component.css
+++ b/src/app/calendar/components/calendar-container/calendar-container.component.css
@@ -45,3 +45,13 @@ mat-card-title {
   border-bottom: 1px solid white;
   padding-bottom: 5px;
 }
+
+.error-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  text-align: center;
+  flex-direction: column;
+  gap: 10px;
+}

--- a/src/app/calendar/components/calendar-container/calendar-container.component.css
+++ b/src/app/calendar/components/calendar-container/calendar-container.component.css
@@ -1,0 +1,47 @@
+.page-container {
+  display: flex;
+  justify-content: center;
+  align-items: top;
+  gap: 1em;
+}
+
+.component-container {
+  width: 33.33%;
+  height: min-content;
+  display: block;
+  text-align: center;
+}
+
+.add-button {
+  margin-right: -3rem;
+  margin-top: -1rem;
+  z-index: 9;
+}
+
+.close-button {
+  margin-left: -3rem;
+  margin-top: -1rem;
+  z-index: 9;
+}
+
+@media (max-width: 800px){
+  .page-container {
+    display: flex;
+    flex-direction: column;
+  }
+  .component-container {
+    width: 90% !important;
+    margin: 1rem;
+  }
+  .add-button, .close-button {
+    margin-right: 0;
+    margin-top: 0;
+    z-index: auto;
+    align-self: center;
+  }
+}
+
+mat-card-title {
+  border-bottom: 1px solid white;
+  padding-bottom: 5px;
+}

--- a/src/app/calendar/components/calendar-container/calendar-container.component.html
+++ b/src/app/calendar/components/calendar-container/calendar-container.component.html
@@ -1,0 +1,20 @@
+<div class="page-container">
+  <button class="add-button" mat-fab color="accent" matTooltip="Add Event" (click)="this.newEvent()">
+    <mat-icon>add</mat-icon>
+  </button>
+  <mat-card class="component-container mat-elevation-z8">
+    <mat-card-content>
+      <app-calendar (dateSelected)="dateSelected($event)"></app-calendar>
+    </mat-card-content>
+  </mat-card>
+  <div class="component-container" *ngIf="this.showForm">
+    <app-event-form [id]="this.eventId" [selectedDate]="this.selectedDate" (complete)="this.cancelForm($event)"></app-event-form>
+  </div>
+  <button class="close-button" mat-fab color="accent" matTooltip="Close Form" (click)="this.cancelForm()" *ngIf="this.showForm">
+    <mat-icon>close</mat-icon>
+  </button>
+  <mat-card class="component-container" *ngIf="this.selectedDate">
+    <mat-card-title>{{this.formatMoment(this.selectedDate)}}</mat-card-title>
+    <app-view-event [selectedDate]="this.selectedDate" (event)="this.editEvent($event)" (hasEvents)="this.hasEvents"></app-view-event>
+  </mat-card>
+</div>

--- a/src/app/calendar/components/calendar-container/calendar-container.component.html
+++ b/src/app/calendar/components/calendar-container/calendar-container.component.html
@@ -1,10 +1,10 @@
 <div class="error-container" *ngIf="this.showError">
-  <h2>Oops! An error occurred. Please try again later.</h2>
-  <button mat-raised-button color="warn" (click)="this.refresh()">Refresh</button>
-  <button mat-raised-button color="warn" routerLink='/homepage'>Home</button>
+  <h2>Whoops! An error occurred.</h2>
+  <button mat-raised-button color="warn" (click)="this.refresh()">Try Again</button>
+  <button mat-raised-button color="warn" routerLink='/homepage'>Go Home</button>
 </div>
 <div class="page-container" *ngIf="!this.showError">
-  <button class="add-button" mat-fab color="accent" matTooltip="Add Event" (click)="this.newEvent()">
+  <button class="add-button" mat-fab color="accent" [matTooltip]="this.selectedDate? 'Add Event' : 'Select a Date'" (click)="this.newEvent()">
     <mat-icon>add</mat-icon>
   </button>
   <mat-card class="component-container mat-elevation-z8">
@@ -12,10 +12,10 @@
       <app-calendar (dateSelected)="dateSelected($event)"></app-calendar>
     </mat-card-content>
   </mat-card>
-  <div class="component-container" *ngIf="this.showForm">
+  <div class="component-container" *ngIf="this.showForm && this.selectedDate">
     <app-event-form [id]="this.eventId" [selectedDate]="this.selectedDate" (complete)="this.cancelForm($event)"></app-event-form>
   </div>
-  <button class="close-button" mat-fab color="accent" matTooltip="Close Form" (click)="this.cancelForm()" *ngIf="this.showForm">
+  <button class="close-button" mat-fab color="accent" matTooltip="Close Form" (click)="this.cancelForm()" *ngIf="this.showForm && this.selectedDate">
     <mat-icon>close</mat-icon>
   </button>
   <mat-card class="component-container" *ngIf="this.selectedDate">

--- a/src/app/calendar/components/calendar-container/calendar-container.component.html
+++ b/src/app/calendar/components/calendar-container/calendar-container.component.html
@@ -1,4 +1,9 @@
-<div class="page-container">
+<div class="error-container" *ngIf="this.showError">
+  <h2>Oops! An error occurred. Please try again later.</h2>
+  <button mat-raised-button color="warn" (click)="this.refresh()">Refresh</button>
+  <button mat-raised-button color="warn" routerLink='/homepage'>Home</button>
+</div>
+<div class="page-container" *ngIf="!this.showError">
   <button class="add-button" mat-fab color="accent" matTooltip="Add Event" (click)="this.newEvent()">
     <mat-icon>add</mat-icon>
   </button>
@@ -15,6 +20,6 @@
   </button>
   <mat-card class="component-container" *ngIf="this.selectedDate">
     <mat-card-title>{{this.formatMoment(this.selectedDate)}}</mat-card-title>
-    <app-view-event [selectedDate]="this.selectedDate" (event)="this.editEvent($event)" (hasEvents)="this.hasEvents"></app-view-event>
+    <app-view-event [selectedDate]="this.selectedDate" (event)="this.editEvent($event)"></app-view-event>
   </mat-card>
 </div>

--- a/src/app/calendar/components/calendar-container/calendar-container.component.spec.ts
+++ b/src/app/calendar/components/calendar-container/calendar-container.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CalendarContainerComponent } from './calendar-container.component';
+
+describe('CalendarContainerComponent', () => {
+  let component: CalendarContainerComponent;
+  let fixture: ComponentFixture<CalendarContainerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CalendarContainerComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CalendarContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/calendar/components/calendar-container/calendar-container.component.ts
+++ b/src/app/calendar/components/calendar-container/calendar-container.component.ts
@@ -11,13 +11,17 @@ import { CalendarEvent } from '../../calendar-event';
 export class CalendarContainerComponent implements OnInit {
 
   selectedDate!: moment.Moment;
-  hasEvents: boolean = false;
   showForm: boolean = false;
   eventId: number = -1;
+  showError: boolean = false;
 
   constructor(private snackbar: MatSnackBar) { }
 
   ngOnInit(): void {
+  }
+
+  refresh(): void {
+    window.location.reload();
   }
 
   formatMoment(date: moment.Moment): string {
@@ -38,12 +42,15 @@ export class CalendarContainerComponent implements OnInit {
   }
 
   cancelForm($event?: boolean) {
+    console.log($event);
     if ($event === true) {
       this.snackbar.open('Saved Event', 'Close', {
         duration: 3000,
         horizontalPosition: 'center',
         verticalPosition: 'bottom'
       });
+    } else if ($event === false){
+      this.showError = true;
     }
     this.eventId = -1;
     this.showForm = false;

--- a/src/app/calendar/components/calendar-container/calendar-container.component.ts
+++ b/src/app/calendar/components/calendar-container/calendar-container.component.ts
@@ -1,0 +1,52 @@
+import { Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import * as moment from 'moment';
+import { CalendarEvent } from '../../calendar-event';
+
+@Component({
+  selector: 'app-calendar-container',
+  templateUrl: './calendar-container.component.html',
+  styleUrls: ['./calendar-container.component.css']
+})
+export class CalendarContainerComponent implements OnInit {
+
+  selectedDate!: moment.Moment;
+  hasEvents: boolean = false;
+  showForm: boolean = false;
+  eventId: number = -1;
+
+  constructor(private snackbar: MatSnackBar) { }
+
+  ngOnInit(): void {
+  }
+
+  formatMoment(date: moment.Moment): string {
+    return moment(date).format("MMMM Do YYYY");
+  }
+
+  dateSelected(value: moment.Moment) {
+    this.selectedDate = value;
+  }
+
+  editEvent(value: CalendarEvent) {
+    this.eventId = value.id;
+    this.showForm = true;
+  }
+
+  newEvent() {
+    this.showForm = true;
+  }
+
+  cancelForm($event?: boolean) {
+    if ($event === true) {
+      this.snackbar.open('Saved Event', 'Close', {
+        duration: 3000,
+        horizontalPosition: 'center',
+        verticalPosition: 'bottom'
+      });
+    }
+    this.eventId = -1;
+    this.showForm = false;
+  }
+
+}

--- a/src/app/calendar/components/calendar-container/calendar-container.component.ts
+++ b/src/app/calendar/components/calendar-container/calendar-container.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import * as moment from 'moment';
+import { Subject } from 'rxjs';
 import { CalendarEvent } from '../../calendar-event';
 
 @Component({
@@ -8,20 +9,32 @@ import { CalendarEvent } from '../../calendar-event';
   templateUrl: './calendar-container.component.html',
   styleUrls: ['./calendar-container.component.css']
 })
-export class CalendarContainerComponent implements OnInit {
+export class CalendarContainerComponent implements OnInit, OnDestroy {
 
-  selectedDate!: moment.Moment;
+  selectedDate!: moment.Moment | null;
   showForm: boolean = false;
   eventId: number = -1;
   showError: boolean = false;
 
+  private clear$ = new Subject<void>();
+
   constructor(private snackbar: MatSnackBar) { }
 
   ngOnInit(): void {
+    this.clear$.subscribe(_ => {
+      this.eventId = -1;
+      this.showForm = false;
+      this.selectedDate = null;
+      this.showError = false;
+    })
+  }
+
+  ngOnDestroy(): void {
+    this.clear$.complete();
   }
 
   refresh(): void {
-    window.location.reload();
+    this.clear$.next();
   }
 
   formatMoment(date: moment.Moment): string {
@@ -38,18 +51,19 @@ export class CalendarContainerComponent implements OnInit {
   }
 
   newEvent() {
-    this.showForm = true;
+    if(this.selectedDate !== null){
+      this.showForm = true;
+    }
   }
 
   cancelForm($event?: boolean) {
-    console.log($event);
     if ($event === true) {
       this.snackbar.open('Saved Event', 'Close', {
         duration: 3000,
         horizontalPosition: 'center',
         verticalPosition: 'bottom'
       });
-    } else if ($event === false){
+    } else if ($event === false) {
       this.showError = true;
     }
     this.eventId = -1;

--- a/src/app/calendar/components/calendar/calendar.component.css
+++ b/src/app/calendar/components/calendar/calendar.component.css
@@ -1,0 +1,11 @@
+::ng-deep .booked .mat-calendar-body-cell-content{
+  background-color: rgba(239, 169, 174, 0.5);
+}
+
+::ng-deep .mat-calendar-body-selected {
+  border: 1px solid white;
+}
+
+::ng-deep .mat-calendar-body-today {
+  border: none !important;
+}

--- a/src/app/calendar/components/calendar/calendar.component.html
+++ b/src/app/calendar/components/calendar/calendar.component.html
@@ -1,0 +1,3 @@
+<mat-calendar #calendar [minDate]="this.minDate" (viewChanged)="viewChanged($event)"
+  (monthSelected)="monthChanged($event)" [(selected)]="selectedDate" (selectedChange)="dateChanged()">
+</mat-calendar>

--- a/src/app/calendar/components/calendar/calendar.component.spec.ts
+++ b/src/app/calendar/components/calendar/calendar.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CalendarComponent } from './calendar.component';
+
+describe('CalendarComponent', () => {
+  let component: CalendarComponent;
+  let fixture: ComponentFixture<CalendarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CalendarComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CalendarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/calendar/components/calendar/calendar.component.ts
+++ b/src/app/calendar/components/calendar/calendar.component.ts
@@ -1,0 +1,100 @@
+import * as moment from 'moment';
+import { AfterViewInit, Component, EventEmitter, OnDestroy, Output, Renderer2, ViewChild } from '@angular/core';
+import { MatCalendar } from '@angular/material/datepicker';
+import { CalendarService } from '../../calendar.service';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'app-calendar',
+  templateUrl: './calendar.component.html',
+  styleUrls: ['./calendar.component.css']
+})
+export class CalendarComponent implements AfterViewInit, OnDestroy{
+
+  selectedDate = moment();
+  minDate: Date = new Date();
+  events!: string[];
+  stringEvents!: Subscription;
+
+  @Output()
+  dateSelected: EventEmitter<moment.Moment> = new EventEmitter();
+
+  @Output()
+  monthSelected: EventEmitter<moment.Moment> = new EventEmitter();
+
+  @ViewChild('calendar', { static: true })
+  calendar!: MatCalendar<moment.Moment>;
+
+  constructor(private renderer: Renderer2, private calendarService: CalendarService) { }
+
+  ngAfterViewInit() {
+    this.setupArrowButtonListeners();
+    this.setMonth();
+    this.stringEvents = this.calendarService.getStringEvents().subscribe(res => this.highlightDays(res));
+  }
+
+  ngOnDestroy() {
+    this.dateSelected.complete();
+    this.monthSelected.complete();
+    this.stringEvents.unsubscribe();
+  }
+
+  private setupArrowButtonListeners() {
+    const buttons = document.querySelectorAll('.mat-calendar-previous-button, .mat-calendar-next-button');
+
+    if (buttons) {
+      Array.from(buttons).forEach(button => {
+        this.renderer.listen(button, 'click', () => {
+          this.monthSelected.emit(this.calendar.activeDate);
+          this.setMonth();
+        });
+      });
+    }
+  }
+
+  monthChanged(date: moment.Moment) {
+    this.monthSelected.emit(date);
+  }
+
+  dateChanged() {
+    this.calendar.activeDate = this.selectedDate;
+    this.dateSelected.emit(this.selectedDate);
+  }
+
+  setMonth() {
+    const month = parseInt(moment(this.calendar.activeDate).format('M'));
+    const year = parseInt(moment(this.calendar.activeDate).format('Y'));
+    this.calendarService.selectMonth(month, year);
+  }
+
+  // Update events when selecting from year view
+  viewChanged(event: 'month' | 'multi-year' | 'year') {
+    if(event === 'month'){
+      this.setMonth();
+    }
+  }
+
+  /**
+ * Method to highlight certain days on the calendar.
+ * This should be used when month selection changes.
+ *
+ * @param days: Array of strings in the format "February 20, 2020"
+ */
+  highlightDays(days: string[]) {
+    let dayElements = document.querySelectorAll(
+      'mat-calendar .mat-calendar-table .mat-calendar-body-cell'
+      );
+    Array.from(dayElements).forEach((element) => {
+      const matchingDay = days.find((d) => d === element.getAttribute('aria-label')) !== undefined;
+
+      if (matchingDay) {
+        this.renderer.addClass(element, 'booked');
+        this.renderer.setAttribute(element, 'title', 'Event(s) Scheduled');
+      } else {
+        this.renderer.removeClass(element, 'booked');
+        this.renderer.removeAttribute(element, 'title');
+      }
+    });
+  }
+
+}

--- a/src/app/calendar/components/calendar/calendar.component.ts
+++ b/src/app/calendar/components/calendar/calendar.component.ts
@@ -62,8 +62,9 @@ export class CalendarComponent implements AfterViewInit, OnDestroy{
   }
 
   setMonth() {
-    const month = parseInt(moment(this.calendar.activeDate).format('M'));
-    const year = parseInt(moment(this.calendar.activeDate).format('Y'));
+    const temp = moment(this.calendar.activeDate);
+    const month = parseInt(temp.format('M'));
+    const year = parseInt(temp.format('Y'));
     this.calendarService.selectMonth(month, year);
   }
 

--- a/src/app/calendar/components/event-form/event-form.component.css
+++ b/src/app/calendar/components/event-form/event-form.component.css
@@ -1,0 +1,13 @@
+.form-container {
+  display: block;
+  text-align: start;
+  height: auto;
+}
+
+mat-form-field {
+  display: block;
+}
+
+button {
+  margin-top: 10px;
+}

--- a/src/app/calendar/components/event-form/event-form.component.html
+++ b/src/app/calendar/components/event-form/event-form.component.html
@@ -1,0 +1,58 @@
+<mat-card class="form-container mat-elevation-z8">
+  <mat-card-title *ngIf="!this.editing">New Event</mat-card-title>
+  <mat-card-title *ngIf="this.editing">Edit Event</mat-card-title>
+  <mat-card-content>
+    <form [formGroup]="eventForm" (ngSubmit)="this.addEvent()" autocomplete="off">
+      <mat-form-field appearance="standard">
+        <mat-label>Date</mat-label>
+        <input matInput formControlName="date" readonly>
+        <mat-error *ngIf="this.eventForm.get('date')?.hasError('required')">
+          Select a date.
+        </mat-error>
+      </mat-form-field>
+
+      <mat-slide-toggle (toggleChange)="this.toggleAllDay()" formControlName="allDay">All-day</mat-slide-toggle>
+
+      <mat-form-field appearance="standard" *ngIf="!this.allDay?.value">
+        <mat-label>Start Time</mat-label>
+        <input type="time" matInput formControlName="startTime" required>
+
+        <mat-error *ngIf="this.eventForm.get('startTime')?.hasError('required')">
+          Provide a start time.
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="standard" *ngIf="!this.allDay?.value">
+        <mat-label>End Time</mat-label>
+        <input type="time" matInput formControlName="endTime" required>
+
+        <mat-error *ngIf="this.eventForm.get('endTime')?.hasError('required')">
+          Provide an end time.
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="standard">
+        <mat-label>Name</mat-label>
+        <input matInput formControlName="name" required>
+
+        <mat-error *ngIf="this.eventForm.get('name')?.hasError('required')">
+          Provide a name for the event.
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="standard">
+        <mat-label>Details</mat-label>
+        <textarea matInput formControlName="details" required></textarea>
+
+        <mat-error *ngIf="this.eventForm.get('details')?.hasError('required')">
+          Provide details for the event.
+        </mat-error>
+      </mat-form-field>
+
+      <button mat-raised-button color="primary" type="submit">
+        <span *ngIf="!this.editing">Add Event</span>
+        <span *ngIf="this.editing">Save Changes</span>
+      </button>
+    </form>
+  </mat-card-content>
+</mat-card>

--- a/src/app/calendar/components/event-form/event-form.component.spec.ts
+++ b/src/app/calendar/components/event-form/event-form.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EventFormComponent } from './event-form.component';
+
+describe('AddEventComponent', () => {
+  let component: EventFormComponent;
+  let fixture: ComponentFixture<EventFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ EventFormComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(EventFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/calendar/components/event-form/event-form.component.ts
+++ b/src/app/calendar/components/event-form/event-form.component.ts
@@ -44,13 +44,11 @@ export class EventFormComponent implements OnDestroy {
       take(1)
     ).subscribe(res => {
       this.date?.setValue(moment(res?.date).format("dddd, MMMM Do YYYY"));
+      this.allDay?.setValue(!res?.allDay);
+      this.toggleAllDay();
       this.allDay?.setValue(res?.allDay);
-      if(res?.allDay){
-        this.toggleAllDay;
-      } else {
-        this.startTime?.setValue(res?.startTime);
-        this.endTime?.setValue(res?.endTime);
-      }
+      this.startTime?.setValue(res?.startTime);
+      this.endTime?.setValue(res?.endTime);
       this.name?.setValue(res?.name);
       this.details?.setValue(res?.details);
     });

--- a/src/app/calendar/components/event-form/event-form.component.ts
+++ b/src/app/calendar/components/event-form/event-form.component.ts
@@ -1,0 +1,151 @@
+import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import * as moment from 'moment';
+import { Observable, take } from 'rxjs';
+import { CalendarEvent } from '../../calendar-event';
+import { CalendarService } from '../../calendar.service';
+
+@Component({
+  selector: 'app-event-form',
+  templateUrl: './event-form.component.html',
+  styleUrls: ['./event-form.component.css']
+})
+export class EventFormComponent implements OnDestroy {
+
+  _selectedDate!: moment.Moment;
+  get selectedDate(): moment.Moment {
+    return this._selectedDate;
+  }
+  @Input() set selectedDate(date: moment.Moment) {
+    this._selectedDate = date;
+    this.date?.setValue(moment(this.selectedDate).format("dddd, MMMM Do YYYY"));
+  }
+
+  event$!: Observable<CalendarEvent | undefined>;
+  editing: boolean = false;
+
+  _id!: number;
+  get id(): number {
+    return this._id;
+  }
+  @Input() set id(num: number) {
+    this._id = num;
+    if (this._id < 0) {
+      return;
+    }
+    this.editing = true;
+    this.calendarService.selectEvent(num);
+    this.event$ = this.calendarService.event$;
+    this.fillForm();
+  }
+
+  fillForm(): void {
+    this.event$.pipe(
+      take(1)
+    ).subscribe(res => {
+      this.date?.setValue(moment(res?.date).format("dddd, MMMM Do YYYY"));
+      this.allDay?.setValue(res?.allDay);
+      if(res?.allDay){
+        this.toggleAllDay;
+      } else {
+        this.startTime?.setValue(res?.startTime);
+        this.endTime?.setValue(res?.endTime);
+      }
+      this.name?.setValue(res?.name);
+      this.details?.setValue(res?.details);
+    });
+  }
+
+  @Output() complete: EventEmitter<boolean> = new EventEmitter();
+
+  eventForm!: FormGroup;
+
+  constructor(private calendarService: CalendarService) {
+    this.eventForm = new FormGroup({
+      'date': new FormControl('', Validators.required),
+      'allDay': new FormControl(''),
+      'startTime': new FormControl('', Validators.required),
+      'endTime': new FormControl('', Validators.required),
+      'name': new FormControl('', Validators.required),
+      'details': new FormControl('', Validators.required)
+    })
+  }
+
+  ngOnDestroy(): void {
+    this.complete.complete();
+  }
+
+  get date() {
+    return this.eventForm.get('date');
+  }
+  get allDay() {
+    return this.eventForm.get('allDay');
+  }
+  get startTime() {
+    return this.eventForm.get('startTime');
+  }
+  get endTime() {
+    return this.eventForm.get('endTime');
+  }
+  get name() {
+    return this.eventForm.get('name');
+  }
+  get details() {
+    return this.eventForm.get('details');
+  }
+
+  dateSelected(value: moment.Moment) {
+    this.selectedDate = value;
+    this.date?.setValue(moment(value).format("dddd, MMMM Do YYYY"));
+  }
+
+  toggleAllDay() {
+    if (!this.allDay?.value) {
+      this.startTime?.clearValidators();
+      this.startTime?.updateValueAndValidity();
+      this.endTime?.clearValidators();
+      this.endTime?.updateValueAndValidity();
+    } else {
+      this.startTime?.addValidators(Validators.required);
+      this.startTime?.updateValueAndValidity();
+      this.endTime?.addValidators(Validators.required);
+      this.endTime?.updateValueAndValidity();
+    }
+  }
+
+  addEvent() {
+    if (this.eventForm.valid) {
+      let event: CalendarEvent = {
+        id: 10,
+        allDay: (this.allDay?.value ? true : false),
+        startTime: (this.allDay?.value ? null : this.startTime?.value),
+        endTime: (this.allDay?.value ? null : this.endTime?.value),
+        date: this.selectedDate,
+        name: this.name?.value,
+        details: this.details?.value
+      }
+      if (this.editing) {
+        event.id = this.id;
+        this.calendarService.editCalendarEvent(event).pipe(
+          take(1)
+        ).subscribe(_ => {
+          this.calendarService.refreshEvents();
+          this.complete.emit(true);
+          return;
+        });
+      } else {
+        this.calendarService.addCalendarEvent(event).pipe(
+          take(1)
+        ).subscribe(_ => {
+          this.calendarService.refreshEvents();
+          this.complete.emit(true);
+          return;
+        });
+      }
+    } else if (this.eventForm.invalid) {
+      return;
+    }
+    this.complete.emit(false);
+  }
+
+}

--- a/src/app/calendar/components/view-event/view-event.component.css
+++ b/src/app/calendar/components/view-event/view-event.component.css
@@ -1,0 +1,21 @@
+.details-container {
+  display: flex;
+  flex-direction: column;
+  height: auto;
+  gap: 10px;
+}
+
+mat-card {
+  text-align: start;
+}
+::ng-deep .mat-card-header-text {
+  margin-left: 0;
+}
+
+.spacer {
+  flex: 1 1 auto;
+}
+
+button {
+  margin-right: 5px;
+}

--- a/src/app/calendar/components/view-event/view-event.component.html
+++ b/src/app/calendar/components/view-event/view-event.component.html
@@ -1,0 +1,28 @@
+<div class="details-container" *ngIf="this.events$ | async as events">
+  <mat-card class="mat-elevation-z8" *ngFor="let event of events">
+    <mat-card-header>
+      <mat-card-title>
+        {{event.name}}
+      </mat-card-title>
+      <mat-card-subtitle>
+        {{this.formatMoment(event.date)}}
+      </mat-card-subtitle>
+      <mat-card-subtitle *ngIf="event.allDay">
+        All-Day
+      </mat-card-subtitle>
+      <mat-card-subtitle *ngIf="!event.allDay">
+        {{event.startTime | timeFormat}} - {{event.endTime | timeFormat}}
+      </mat-card-subtitle>
+      <span class="spacer"></span>
+      <button mat-mini-fab color="primary" matTooltip="Edit Event" (click)="this.editEvent(event)">
+        <mat-icon>edit</mat-icon>
+      </button>
+      <button mat-mini-fab color="warn" matTooltip="Delete Event" (click)="this.deleteEvent(event.id)">
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-card-header>
+    <mat-card-content *ngIf="event.details">
+      {{event.details}}
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/src/app/calendar/components/view-event/view-event.component.spec.ts
+++ b/src/app/calendar/components/view-event/view-event.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewEventComponent } from './view-event.component';
+
+describe('ViewEventComponent', () => {
+  let component: ViewEventComponent;
+  let fixture: ComponentFixture<ViewEventComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ViewEventComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ViewEventComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/calendar/components/view-event/view-event.component.ts
+++ b/src/app/calendar/components/view-event/view-event.component.ts
@@ -1,0 +1,51 @@
+import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import * as moment from 'moment';
+import { Observable, take } from 'rxjs';
+import { CalendarEvent } from '../../calendar-event';
+import { CalendarService } from '../../calendar.service';
+
+@Component({
+  selector: 'app-view-event',
+  templateUrl: './view-event.component.html',
+  styleUrls: ['./view-event.component.css']
+})
+
+export class ViewEventComponent implements OnDestroy{
+
+  _selectedDate!: moment.Moment;
+  get selectedDate(): moment.Moment {
+    return this._selectedDate;
+  }
+  @Input() set selectedDate(date: moment.Moment) {
+    this._selectedDate = date;
+    this.getEvents();
+  }
+
+  @Output() event: EventEmitter<CalendarEvent> = new EventEmitter();
+
+  events$!: Observable<CalendarEvent[]>;
+
+  constructor(private calendarService: CalendarService) { }
+
+  ngOnDestroy(): void {
+    this.event.complete();
+  }
+
+  formatMoment(x: moment.Moment): string{
+    return moment(x).format("dddd, MMMM Do YYYY");
+  }
+
+  getEvents() {
+    this.events$ = this.calendarService.getDayEvents(this.selectedDate);
+  }
+
+  editEvent(event: CalendarEvent){
+    this.event.emit(event);
+  }
+
+  deleteEvent(id: number){
+    this.calendarService.deleteCalendarEvent(id).pipe(
+      take(1)
+    ).subscribe(_ => this.calendarService.refreshEvents());
+  }
+}

--- a/src/app/in-memory-data.service.ts
+++ b/src/app/in-memory-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { InMemoryDbService, RequestInfo } from 'angular-in-memory-web-api';
-import { Observable } from 'rxjs';
+import { InMemoryDbService } from 'angular-in-memory-web-api';
+import * as moment from 'moment';
 import { Pet } from './pet';
 
 @Injectable({
@@ -10,37 +10,37 @@ export class InMemoryDataService implements InMemoryDbService {
   createDb() {
     const pets = [
       {
+        id: 1,
+        name: 'Cassidy',
+        breed: 'Domestic Shorthair',
+        color: 'Brown',
+        description: 'Hates kids',
+        microchip: '7245565187654',
+        sex: 'Male',
+        fixed: false,
+        weight: 4.3,
+        birthday: new Date('11/12/2019'),
+        adoptionDay: new Date('02/14/2020'),
+        petPhoto: '/assets/default.png',
+        vetRecords: '/assets/vet-records.pdf',
+        prescriptions: [{
           id: 1,
-          name: 'Cassidy',
-          breed: 'Domestic Shorthair',
-          color: 'Brown',
-          description: 'Hates kids',
-          microchip: '7245565187654',
-          sex: 'Male',
-          fixed: false,
-          weight: 4.3,
-          birthday: new Date('11/12/2019'),
-          adoptionDay: new Date('02/14/2020'),
-          petPhoto: '/assets/default.png',
-          vetRecords: '/assets/vet-records.pdf',
-          prescriptions: [{
-            id: 1,
-            name: 'Baytril',
-            doctor: 'Dr. Young',
-            due:  new Date('04/17/2020'),
-            refills: 3
-          }],
-          vaccines: [{
-              id: 1,
-              name: 'Rabies',
-              dateAdministered: new Date('12/16/2020'),
-              dueDate: new Date('12/16/2021')
-          }],
-          conditions: [{
-            id: 1,
-            name: 'URI',
-            notes: 'Baytril is to treat this infection. Should clear up this week.'
-          }]
+          name: 'Baytril',
+          doctor: 'Dr. Young',
+          due: new Date('04/17/2020'),
+          refills: 3
+        }],
+        vaccines: [{
+          id: 1,
+          name: 'Rabies',
+          dateAdministered: new Date('12/16/2020'),
+          dueDate: new Date('12/16/2021')
+        }],
+        conditions: [{
+          id: 1,
+          name: 'URI',
+          notes: 'Baytril is to treat this infection. Should clear up this week.'
+        }]
       },
       {
         id: 2,
@@ -59,100 +59,161 @@ export class InMemoryDataService implements InMemoryDbService {
           id: 1,
           name: 'Baytril',
           doctor: 'Dr. Young',
-          due:  new Date('04/17/2020'),
+          due: new Date('04/17/2020'),
           refills: 3
         }],
         vaccines: [{
-            id: 1,
-            name: 'Rabies',
-            dateAdministered: new Date('12/16/2020'),
-            dueDate: new Date('12/16/2021')
+          id: 1,
+          name: 'Rabies',
+          dateAdministered: new Date('12/16/2020'),
+          dueDate: new Date('12/16/2021')
         }],
         conditions: [{
           id: 1,
           name: 'URI',
           notes: 'Baytril is to treat this infection. Should clear up this week.'
         }]
-    },
-    {
-      id: 3,
-      name: 'Megan',
-      breed: 'Domestic Shorthair',
-      color: 'Brown',
-      description: 'Hates kids',
-      microchip: '7245565187654',
-      sex: 'Female',
-      fixed: false,
-      weight: 4.3,
-      birthday: new Date('11/12/2019'),
-      adoptionDay: new Date('02/14/2020'),
-      petPhoto: '/assets/default.png',
-      prescriptions: [{
-        id: 1,
-        name: 'Baytril',
-        doctor: 'Dr. Young',
-        due:  new Date('04/17/2020'),
-        refills: 3
-      }],
-      vaccines: [{
+      },
+      {
+        id: 3,
+        name: 'Megan',
+        breed: 'Domestic Shorthair',
+        color: 'Brown',
+        description: 'Hates kids',
+        microchip: '7245565187654',
+        sex: 'Female',
+        fixed: false,
+        weight: 4.3,
+        birthday: new Date('11/12/2019'),
+        adoptionDay: new Date('02/14/2020'),
+        petPhoto: '/assets/default.png',
+        prescriptions: [{
+          id: 1,
+          name: 'Baytril',
+          doctor: 'Dr. Young',
+          due: new Date('04/17/2020'),
+          refills: 3
+        }],
+        vaccines: [{
           id: 1,
           name: 'Rabies',
           dateAdministered: new Date('12/16/2020'),
           dueDate: new Date('12/16/2021')
-      }],
-      conditions: [{
+        }],
+        conditions: [{
+          id: 1,
+          name: 'URI',
+          notes: 'Baytril is to treat this infection. Should clear up this week.'
+        },
+        {
+          id: 2,
+          name: 'Tripawd',
+          notes: 'Leg Amputated'
+        }]
+      },
+      {
+        id: 4,
+        name: 'Ezra',
+        breed: 'Domestic Shorthair',
+        color: 'Brown',
+        description: 'Hates kids',
+        microchip: '7245565187654',
+        sex: 'Male',
+        fixed: true,
+        weight: 4.3,
+        birthday: new Date('11/12/2019'),
+        adoptionDay: new Date('02/14/2020'),
+        petPhoto: '/assets/default.png',
+        prescriptions: [{
+          id: 1,
+          name: 'Baytril',
+          doctor: 'Dr. Young',
+          due: new Date('04/17/2020'),
+          refills: 3
+        }],
+        vaccines: [{
+          id: 1,
+          name: 'Rabies',
+          dateAdministered: new Date('12/16/2020'),
+          dueDate: new Date('12/16/2021')
+        }],
+        conditions: [{
+          id: 1,
+          name: 'URI',
+          notes: 'Baytril is to treat this infection. Should clear up this week.'
+        }]
+      }
+    ]
+    const events = [
+      {
         id: 1,
-        name: 'URI',
-        notes: 'Baytril is to treat this infection. Should clear up this week.'
+        date: moment().day(3),
+        allDay: true,
+        name: 'Test Event',
+        details: 'details example. testing here. some extra text. examples test.'
       },
       {
         id: 2,
-        name: 'Tripawd',
-        notes: 'Leg Amputated'
-      }]
-  },
-  {
-    id: 4,
-    name: 'Ezra',
-    breed: 'Domestic Shorthair',
-    color: 'Brown',
-    description: 'Hates kids',
-    microchip: '7245565187654',
-    sex: 'Male',
-    fixed: true,
-    weight: 4.3,
-    birthday: new Date('11/12/2019'),
-    adoptionDay: new Date('02/14/2020'),
-    petPhoto: '/assets/default.png',
-    prescriptions: [{
-      id: 1,
-      name: 'Baytril',
-      doctor: 'Dr. Young',
-      due:  new Date('04/17/2020'),
-      refills: 3
-    }],
-    vaccines: [{
-        id: 1,
-        name: 'Rabies',
-        dateAdministered: new Date('12/16/2020'),
-        dueDate: new Date('12/16/2021')
-    }],
-    conditions: [{
-      id: 1,
-      name: 'URI',
-      notes: 'Baytril is to treat this infection. Should clear up this week.'
-    }]
-  }
-  ]
-    return {pets};
+        date: moment().day(12),
+        allDay: true,
+        name: 'Test Event',
+        details: 'details example. testing here. some extra text. examples test.'
+      },
+      {
+        id: 3,
+        date: moment().day(12),
+        allDay: true,
+        name: 'Test Event',
+        details: 'details example. testing here. some extra text. examples test.'
+      },
+      {
+        id: 4,
+        date: moment().day(20),
+        allDay: true,
+        name: 'Test Event',
+        details: 'details example. testing here. some extra text. examples test.'
+      },
+      {
+        id: 5,
+        date: moment(),
+        allDay: false,
+        startTime: "03:30",
+        endTime: "15:30",
+        name: 'Test Event',
+        details: 'details example. testing here. some extra text. examples test.'
+      },
+      {
+        id: 6,
+        date: moment().day(12),
+        allDay: false,
+        startTime: "11:30",
+        endTime: "21:30",
+        name: 'Test Event',
+        details: 'details example. testing here. some extra text. examples test.'
+      },
+      {
+        id: 7,
+        date: moment(),
+        allDay: false,
+        startTime: "08:30",
+        endTime: "17:30",
+        name: 'Test Event',
+        details: 'details example. testing here. some extra text. examples test.'
+      },
+      {
+        id: 8,
+        date: moment().day(42),
+        allDay: false,
+        startTime: "03:30",
+        endTime: "15:30",
+        name: 'Test Event',
+        details: 'details example. testing here. some extra text. examples test.'
+      }
+    ]
+    return { pets, events };
   }
 
-  // Overrides the genId method to ensure that a hero always has an id.
-  // If the heroes array is empty,
-  // the method below returns the initial number (11).
-  // if the heroes array is not empty, the method below returns the highest
-  // hero id + 1.
-  genId(pets: Pet[]): number {
-    return pets.length > 0 ? Math.max(...pets.map(pet => pet.id)) + 1 : 11;
+  genId(ary: any[]): number {
+    return ary.length > 0 ? Math.max(...ary.map(ary => ary.id)) + 1 : 11;
   }
 }

--- a/src/app/main-nav/main-nav.component.html
+++ b/src/app/main-nav/main-nav.component.html
@@ -6,7 +6,7 @@
     <mat-toolbar>Hi, User!</mat-toolbar>
     <mat-nav-list>
       <a mat-list-item routerLink="/pets">My Pets</a>
-      <a mat-list-item routerLink="">Calendar</a>
+      <a mat-list-item routerLink="/calendar">Calendar</a>
       <a mat-list-item routerLink="">Bookmarks</a>
       <a mat-list-item routerLink="/profile">Settings</a>
     </mat-nav-list>

--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -37,9 +37,12 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 
+import { TimeFormatPipe } from './pipes/time-format.pipe'; //move to shared module after merge
 
 @NgModule({
-  declarations: [],
+  declarations: [
+    TimeFormatPipe //move
+  ],
   exports: [
     MatAutocompleteModule,
     MatCheckboxModule,
@@ -76,7 +79,8 @@ import { MatTableModule } from '@angular/material/table';
     MatTooltipModule,
     MatPaginatorModule,
     MatSortModule,
-    MatTableModule
+    MatTableModule,
+    TimeFormatPipe //Move
   ]
 })
 export class MaterialModule { }

--- a/src/app/shared/pipes/time-format.pipe.spec.ts
+++ b/src/app/shared/pipes/time-format.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { TimeFormatPipe } from './time-format.pipe';
+
+describe('TimeFormatPipe', () => {
+  it('create an instance', () => {
+    const pipe = new TimeFormatPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/shared/pipes/time-format.pipe.ts
+++ b/src/app/shared/pipes/time-format.pipe.ts
@@ -1,0 +1,38 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'timeFormat'
+})
+export class TimeFormatPipe implements PipeTransform {
+
+  transform(value: String | undefined): string {
+    if(!value) {
+      return '';
+    }
+    let str = "";
+    let hours = parseInt(value.slice(0, 2));
+    let minutes = parseInt(value.slice(3));
+
+    let indicator = 'PM';
+    if(hours < 12) {
+      indicator = 'AM';
+    }
+    if (hours >= 13) {
+      hours -= 12;
+    }
+    if (hours === 0) {
+      hours = 12;
+    }
+    str += hours + ":";
+
+
+    if(minutes < 10){
+      str += "0";
+    }
+    str += minutes + " ";
+    str += indicator;
+
+    return str;
+  }
+
+}


### PR DESCRIPTION
The calendar view is made up of four components. Originally I thought I was going to make this into a new module, but I decided that each component displayed together made more sense. I am using the mat-calendar component (contained in Calendar) to display the datepicker calendar in a larger size and with some CSS modifications to convey scheduled events. The EventForm is to add/edit events, ViewEvent shows all events on a selected day, and CalendarContainer holds all of the components, handles their visibility, and transfers some data between them. I also created an interface and service to mock the functionality.